### PR TITLE
Add the ability to set up a Fedora 32 system for subman development

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,7 @@ distro_specific_deps:
   - yum-utils
 libexec_path: /usr/libexec
 install_cockpit: True
+install_yarn_via_npm: True
 sitecustomize_path: /usr/lib/python{{ ansible_python_version|regex_replace('^([^\.]*\.[^\.]*)\..*$', '\1') }}/site-packages/sitecustomize.py
 builddep_command: yum-builddep
 setup_xforwarding: yes

--- a/tasks/cockpit.yml
+++ b/tasks/cockpit.yml
@@ -11,3 +11,14 @@
     enabled: yes
     state: started
   become: yes
+
+- name: install webpack globally
+  npm:
+    name: webpack
+    global: yes
+    path: /vagrant/subscription-manager/cockpit
+
+- name: install cockpit packages
+  npm:
+    state: latest
+    path: /vagrant/subscription-manager/cockpit

--- a/tasks/cockpit.yml
+++ b/tasks/cockpit.yml
@@ -17,6 +17,7 @@
     name: webpack
     global: yes
     path: /vagrant/subscription-manager/cockpit
+  become: yes
 
 - name: install cockpit packages
   npm:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,7 +93,7 @@
   args:
     creates: "{{ ansible_user_dir }}/.nvm"
     warn: no
-  when: install_cockpit
+  when: install_cockpit and install_yarn_via_npm
 
 - name: use nvm to install nodejs
   shell: >
@@ -103,7 +103,7 @@
     nvm alias default {{ subman_nodejs_version }}"
   args:
     creates: "{{ ansible_user_dir }}/.nvm/versions/node/{{ subman_nodejs_version }}"
-  when: install_cockpit
+  when: install_cockpit and install_yarn_via_npm
 
 - name: install yarn (for cockpit package build)
   npm:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,13 @@
 ---
+- name: load distribution-specific vars (major version)
+  include_vars: "{{ item }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_distribution }}{{ ansible_distribution_major_version }}.yml"
+      paths: vars
+      skip: yes
+  register: distro_vars
+
 - name: load distribution-specific vars
   include_vars: "{{ item }}"
   with_first_found:
@@ -6,6 +15,7 @@
         - "{{ ansible_distribution }}.yml"
       paths: vars
       skip: yes
+  when: not distro_vars
 - name: install epel (centos)
   yum:
     name: epel-release

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -112,7 +112,7 @@
     global: yes
   environment:
     PATH: "{{ ansible_user_dir }}/.nvm/versions/node/{{ subman_nodejs_version }}/bin"
-  when: install_cockpit
+  when: install_cockpit and install_yarn_via_npm
 
 - include: cockpit.yml
   when: ansible_distribution == 'Fedora' or (ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7') or (ansible_distribution == 'RedHat' and (ansible_distribution_major_version == '8' or ansible_distribution_major_version == '7')) and install_cockpit

--- a/vars/Fedora32.yml
+++ b/vars/Fedora32.yml
@@ -12,8 +12,9 @@ distro_specific_deps:
   - python3-dbus
   - subscription-manager
   - tito
+  - yarnpkg
   - xorg-x11-server-Xvfb
 builddep_command: dnf builddep
 distro_package_command: dnf
 subman_python_interpreter: python3
-subman_nodejs_version: v14.7.0
+install_yarn_via_npm: False

--- a/vars/Fedora32.yml
+++ b/vars/Fedora32.yml
@@ -7,12 +7,12 @@ distro_specific_deps:
   - librsvg2
   - libxslt-devel
   - make
+  - npm
   - python3-dmidecode
   - python3-ethtool
   - python3-dbus
   - subscription-manager
   - tito
-  - yarnpkg
   - xorg-x11-server-Xvfb
 builddep_command: dnf builddep
 distro_package_command: dnf

--- a/vars/Fedora32.yml
+++ b/vars/Fedora32.yml
@@ -1,0 +1,19 @@
+distro_specific_deps:
+  - dbus-x11
+  - dnf-utils
+  - gcc
+  - git
+  - koji
+  - librsvg2
+  - libselinux-python
+  - libxslt-devel
+  - make
+  - python3-dmidecode
+  - python3-ethtool
+  - python3-dbus
+  - subscription-manager
+  - tito
+  - xorg-x11-server-Xvfb
+builddep_command: dnf builddep
+distro_package_command: dnf
+subman_python_interpreter: python3

--- a/vars/Fedora32.yml
+++ b/vars/Fedora32.yml
@@ -16,3 +16,4 @@ distro_specific_deps:
 builddep_command: dnf builddep
 distro_package_command: dnf
 subman_python_interpreter: python3
+subman_nodejs_version: v14.7.0

--- a/vars/Fedora32.yml
+++ b/vars/Fedora32.yml
@@ -5,7 +5,6 @@ distro_specific_deps:
   - git
   - koji
   - librsvg2
-  - libselinux-python
   - libxslt-devel
   - make
   - python3-dmidecode

--- a/vars/Fedora32.yml
+++ b/vars/Fedora32.yml
@@ -3,6 +3,7 @@ distro_specific_deps:
   - dnf-utils
   - gcc
   - git
+  - glibc-all-langpacks
   - koji
   - librsvg2
   - libxslt-devel
@@ -11,6 +12,7 @@ distro_specific_deps:
   - python3-dmidecode
   - python3-ethtool
   - python3-dbus
+  - pygtk2
   - subscription-manager
   - tito
   - xorg-x11-server-Xvfb


### PR DESCRIPTION
This PR adds a couple things, which collectively allow for the ansible role to set up a fedora 32 system to do subscription-manager development:

* When yarn is available via the distro's package manager (as indicated in the distro specific vars) install it from that source
* Remove unnecessary and old dependencies for doing subscription-manager dev on fedora
* Allow the playbook to support multiple versions of the same distro specified by distro major version. This allows different sets of distro specific variables to be specified for say fedora 32 vs fedora33 if necessary. It was implemented this way so as to not break compatibility.